### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ WARNING: The Live Share extension required .NET Core SDK 3, which is not present
     }}/modules/vsliveshare/home.nix"
   ];
 
-  services.vsliveshare.enable = true;
-  extensionsDir = "$HOME/.vscode-oss/extensions";
-  nixpkgsPath = builtins.fetchGit {
-    url = "https://github.com/NixOS/nixpkgs.git";
-    ref = "refs/heads/nixos-20.03";
-    rev = "61cc1f0dc07c2f786e0acfd07444548486f4153b";
+  services.vsliveshare = {
+      enable = true;
+      extensionsDir = "$HOME/.vscode-oss/extensions";
+      nixpkgsPath = "${builtins.fetchGit {
+          url = "https://github.com/NixOS/nixpkgs.git";
+          ref = "refs/heads/nixos-20.03";
+          rev = "61cc1f0dc07c2f786e0acfd07444548486f4153b";
+      }}";
   };
 }
 ```


### PR DESCRIPTION
Some nesting changes.

Also, I was getting

> error: The option value `services.vsliveshare.nixpkgsPath' in `/home/weber/.configfiles/nix/home-manager/vscode' is not of type `string'.

So I wrapped the path in a string, which seems to be working now.